### PR TITLE
refactor!: rename unity asmdef from Alxtrkvh.Omnihavior to Omnihavior

### DIFF
--- a/Omnihavior.Unity/Runtime/Alxtrkhv.Omnihavior.asmdef.meta
+++ b/Omnihavior.Unity/Runtime/Alxtrkhv.Omnihavior.asmdef.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 0dbf28983e2d24472bf197712e853fa1
-AssemblyDefinitionImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Omnihavior.Unity/Runtime/Omnihavior.asmdef
+++ b/Omnihavior.Unity/Runtime/Omnihavior.asmdef
@@ -1,5 +1,5 @@
 {
-  "name": "Alxtrkhv.Omnihavior",
+  "name": "Omnihavior",
   "rootNamespace": "Omnihavior",
   "references": [],
   "includePlatforms": [],

--- a/Omnihavior.Unity/Runtime/Omnihavior.asmdef.meta
+++ b/Omnihavior.Unity/Runtime/Omnihavior.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0dbf28983e2d24472bf197712e853fa1
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Doing this to maintain consistency with the namespace and other libraries